### PR TITLE
optirun does not recognize if several instances are running

### DIFF
--- a/install-files/optirun64.ubuntu
+++ b/install-files/optirun64.ubuntu
@@ -13,7 +13,7 @@ export $VGL_READBACK
 vglrun -c $VGL_COMPRESS -d $VGL_DISPLAY -ld /usr/lib/nvidia-current $@
 
 if [ "$STOP_SERVICE_ON_EXIT" != "NO" ]; then
- if [ `ps aux |grep vglrun |wc -l` -lt 2 ]; then
+ if [ `ps aux |grep optirun |wc -l` -lt 4 ]; then
   sudo /etc/init.d/bumblebee disable
  else
   echo "Another bumblebee powered application is running, keeping bumblebee alive."


### PR DESCRIPTION
"vglrun" exchanged by "optirun" because with the first one the value is constant and is equal to 1.
With the 4 in condition is a little bit complicated: the 1st is the process itself, the 2nd comes from grep and the 3rd one I could not figure out where it comes from but this setup works for me.
