### PR TITLE
Support in determinedistro for backtrack5 (ubuntu)

### DIFF
--- a/stages/determinedistro
+++ b/stages/determinedistro
@@ -9,7 +9,7 @@ elif [ `cat /etc/issue |grep -nir debian |wc -l` -gt 0 ]; then
   echo
   read
   exit 1
-elif [ `cat /etc/issue |grep -nir ubuntu |wc -l` -gt 0 ] || [ `cat /etc/issue |grep -nir "Linux Mint" |wc -l` -gt 0 ]; then
+elif [ `cat /etc/issue |grep -nir ubuntu |wc -l` -gt 0 ] || [ `cat /etc/issue |grep -nir "Linux Mint" |wc -l` -gt 0 ] || [ `cat /etc/issue |grep -nir "Backtrack 5" |wc -l` -gt 0 ]; then
   DISTRO=UBUNTU
 elif [ `cat /etc/issue |grep -nir openSUSE |wc -l` -gt 0 ]; then
   DISTRO=OPENSUSE


### PR DESCRIPTION
Pretty straight forward, been trying to get Backtrack5 to work on my Vostro 3400.

It might be better to just grep for backtrack instead of the version number, but I remember some of the earlier versions being based on something besides Ubuntu, so i kept it specific to what I knew.
