### PR TITLE
Confirmed: ASUS UL80VT is working with Bumblebee

### DIFF
--- a/README
+++ b/README
@@ -135,6 +135,7 @@ Dell XPS 17 L702x			Stephen Brooks
 Asus U30JC				paralocatucalva
 Alienware M11X R1			Joseph Livecchi
 Acer Aspire 8951G			Paul Hinds
+Asus UL80VT                             Maegras
 
 Machines working with automatic power management of the nVidia card:
 


### PR DESCRIPTION
New Laptop working with Bumblebee: ASUS UL80VT
