### PR TITLE
Bugfix for uninstall, disable/enable scripts for T410, powersave on wakeup

### DIFF
--- a/install-files/bumblebee-disablecard-on-powerup
+++ b/install-files/bumblebee-disablecard-on-powerup
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+
+DISABLECARD=/usr/local/bin/bumblebee-disablecard
+
+####
+## This script disables Nvidia card if no optirun is running.
+####
+if [  `ps aux |grep optirun|wc -l` -lt 2 ]; then
+	$DISABLECARD
+fi

--- a/install-files/bumblebee-disablecard.t410
+++ b/install-files/bumblebee-disablecard.t410
@@ -1,0 +1,37 @@
+#!/bin/bash
+# This script should contain the command(s) nessesary to switch off the
+# nVidia card.
+# As an example i've included the script for my Alienware M11X R2..
+# Please note that the acpi_call module is need for these operations:
+#
+# http://linux-hybrid-graphics.blogspot.com/2010/07/using-acpicall-module-to-switch-onoff.html
+
+if [ `lsmod | grep nvidia | wc -l` -gt  0 ]; then
+	rmmod nvidia
+	echo "nvidia module unloaded"
+fi;
+
+modprobe acpi_call
+
+if ! lsmod | grep -q acpi_call; then
+    echo "Error: acpi_call module not loaded"
+    exit
+fi
+
+acpi_call () {
+    echo "$*" > /proc/acpi/call
+
+    result=$(cat /proc/acpi/call)
+    case "$result" in
+     Error*)       
+      echo "Disabling nVidia Card failed ($result)."
+      ;;                          
+     *)                                   
+      echo "Disabling nVidia Card Succeded."                                                                                
+     ;;                                                                   
+    esac   
+}
+
+
+echo _PS3 $(acpi_call "\_SB.PCI0.PEG.VID._PS3")
+echo OFF $(acpi_call "\_SB.PCI0.PEG.VID._OFF")

--- a/install-files/bumblebee-enablecard.t410
+++ b/install-files/bumblebee-enablecard.t410
@@ -1,0 +1,23 @@
+#!/bin/bash
+# This script should contain the command(s) nessesary to switch on the
+# nVidia card.
+# As an example i've included the script for my Alienware M11X R2..
+# Please note that the acpi_call module is need for these operations:
+#
+# http://linux-hybrid-graphics.blogspot.com/2010/07/using-acpicall-module-to-switch-onoff.html
+
+modprobe acpi_call
+
+if ! lsmod | grep -q acpi_call; then
+    echo "Error: acpi_call module not loaded"
+    exit
+fi
+
+acpi_call () {
+    echo "$*" > /proc/acpi/call
+    cat /proc/acpi/call
+}
+
+echo ON $(acpi_call "\_SB.PCI0.PEG.VID._ON")
+echo _PS0 $(acpi_call "\_SB.PCI0.PEG.VID._PS0")
+modprobe nvidia-current

--- a/install-files/bumblebee-uninstall
+++ b/install-files/bumblebee-uninstall
@@ -93,6 +93,7 @@ if [ $DISTRO = UBUNTU  ] || [ $DISTRO = DEBIAN  ]; then
  echo
  dpkg -r VirtualGL
  update-rc.d -f bumblebee remove
+ rm /etc/pm/power.d/bumblebee-disablecard-on-powerup
 elif [ $DISTRO = FEDORA  ] || [ $DISTRO = OPENSUSE  ]; then
  echo "Removing VirtualGL package"
  echo
@@ -123,6 +124,7 @@ rm /usr/bin/xdm-optimus
 rm -rf /usr/lib64/nvidia-current
 rm -rf /usr/lib/nvidia-current
 rm /usr/local/bin/optirun*
+rm /usr/local/bin/bumblebee-disablecard-on-powerup
 rm /usr/bin/vglclient-service
 rm /etc/modprobe.d/nouveau-blacklist.conf
 rm -rf /usr/share/doc/bumblebee
@@ -156,7 +158,6 @@ grep -Ev 'VGL|optirun' $HOME/.bashrc > $HOME/.oldbashrc
 mv $HOME/.oldbashrc $HOME/.bashrc
 grep -Ev 'bumblebee' /etc/sudoers > /etc/sudoers.optiorig
 mv /etc/sudoers.optiorig /etc/sudoers
-
 chmod 0440 /etc/sudoers
 
 killall -9 vglclient

--- a/stages/installbumblebee.UBUNTU
+++ b/stages/installbumblebee.UBUNTU
@@ -18,6 +18,17 @@ else
  echo
 fi
 
+if [ ! -f /usr/local/bin/bumblebee-disablecard-on-powerup ]; then
+ # Not installed
+ cp install-files/bumblebee-disablecard-on-powerup /usr/local/bin/
+ ln -s /usr/local/bin/bumblebee-disablecard-on-powerup /etc/pm/power.d/
+else
+ # Already Exists
+ echo
+ echo "nVidia card disable-on-powerup-script: /usr/local/bin/bumblebee-disablecard-on-powerup, already exists not overwriting"
+ echo
+fi
+
 if [ -f /etc/default/bumblebee ]; then
   # Already Exists
   echo


### PR DESCRIPTION
```
new file: install-files/bumblebee-disablecard-on-powerup
    Script should be put into /etc/pm/power.d (on Ubuntu) to disable Nvidia card on wake after 
    suspend and powerup up if there is no optirun executing to save power.
new file:   install-files/bumblebee-disablecard.t410
new file:   install-files/bumblebee-enablecard.t410
    Enable- and disablecard scripts for Lenovo T410
modified:   install-files/bumblebee-uninstall
    There is a bug which sets the permissions on sudoers file to 0777. Fixed by changing 
    them explicitly to 0440.
modified:   stages/installbumblebee.UBUNTU
    Installation of the softlink for "bumblebee-disablecard-on-powerup" script has been added. 
    Need to check if it is applicable to other distribution
```
