### PR TITLE
Fixes for uninstall script

### DIFF
--- a/install-files/bumblebee-uninstall
+++ b/install-files/bumblebee-uninstall
@@ -160,7 +160,7 @@ fi
 
 grep -Ev 'VGL|optirun' $HOME/.bashrc > $HOME/.oldbashrc
 mv $HOME/.oldbashrc $HOME/.bashrc
-chown $USER:$USER .bashrc
+chown $USER:$USER $HOME/.bashrc
 grep -Ev 'bumblebee' /etc/sudoers > /etc/sudoers.optiorig
 mv /etc/sudoers.optiorig /etc/sudoers
 chmod 0440 /etc/sudoers


### PR DESCRIPTION
Set owner of $HOME/.bashrc back to user (after uninstalling it's owned by root)
/usr/local/bumblebee-uninstall is already removed above
