### PR TITLE
If Ubuntu version is oneiric, don't add x-swat PPA.

### DIFF
--- a/stages/packageinstall.UBUNTU
+++ b/stages/packageinstall.UBUNTU
@@ -3,6 +3,10 @@ if [ $VERSION = 11.04 ]; then
  echo
  echo "Ubuntu 11.04 Detected."
  echo
+elif [ $VERSION = oneiric ]; then
+ echo
+ echo "Ubuntu 11.10 oneiric detected."
+ echo
 else 
  echo
  echo "Ubuntu "$VERSION" Detected."


### PR DESCRIPTION
Currently, if I install bumblebee on oneiric, install.sh adds the x-swat drivers PPA which isn't needed. Oneiric is newer than Ubuntu 11.04, so new that even the x-swat PPA doesn't contain packages for oneiric :)

Also, in the code I'm matching it with oneiric because the issue file in oneiric contains "ubuntu oneiric" and not "ubuntu 11.04".
