### PR TITLE
U43Jc support

### DIFF
--- a/install-files/bumblebee-disablecard.U43Jc
+++ b/install-files/bumblebee-disablecard.U43Jc
@@ -1,0 +1,34 @@
+#!/bin/bash
+# This script should contain the command(s) nessesary to switch off the
+# nVidia card.
+# This is a template script..
+# Please note that the acpi_call module is need for these operations:
+#
+# http://linux-hybrid-graphics.blogspot.com/2010/07/using-acpicall-module-to-switch-onoff.html
+
+rmmod nvidia
+if lsmod | grep -q nvidia; then
+ echo "Error: could not unload nvidia module, leaving card turned on"
+ exit
+fi
+modprobe acpi_call
+
+if ! lsmod | grep -q acpi_call; then
+    echo "Error: acpi_call module not loaded"
+    exit
+fi
+
+acpi_call () {
+    echo "$*" > /proc/acpi/call
+    result=$(cat /proc/acpi/call)
+    case "$result" in
+     Error*)       
+      echo "Disabling nVidia Card failed ($result)."
+      ;;                          
+     *)                                   
+      echo "Disabling nVidia Card Succeded."                                                                                
+     ;;                                                                   
+    esac   
+}
+
+echo _PS3 $(acpi_call "\_SB.PCI0.RP00.VGA._PS3")

--- a/install-files/bumblebee-enablecard.U43Jc
+++ b/install-files/bumblebee-enablecard.U43Jc
@@ -1,0 +1,31 @@
+#!/bin/bash
+# This script should contain the command(s) nessesary to switch on the
+# nVidia card.
+# This is a Template Script
+# Please note that the acpi_call module is need for these operations:
+#
+# http://linux-hybrid-graphics.blogspot.com/2010/07/using-acpicall-module-to-switch-onoff.html
+
+modprobe acpi_call
+
+if ! lsmod | grep -q acpi_call; then
+    echo "Error: acpi_call module not loaded"
+    exit
+fi
+
+acpi_call () {
+    echo "$*" > /proc/acpi/call
+    result=$(cat /proc/acpi/call)
+    case "$result" in
+     Error*)
+      echo "Enabling nVidia Card failed ($result)."
+      ;;
+     *)
+      echo "Enabling nVidia Card Succeded."
+     ;;
+    esac
+}
+
+echo _PS0 $(acpi_call "\_SB.PCI0.RP00.VGA._PS0")
+
+modprobe nvidia-current


### PR DESCRIPTION
These are the scripts for Asus U43Jc.

However, for this specific model, we need to recompile kernel with a custom DSDT for acpi calls to work (see http://ubuntuforums.org/showthread.php?t=1615564). I think this is because none of us know acpi quite enough to understand what go wrong without this modification.

So these scripts are supposing you did it.
