### PR TITLE
1015PN script related changes

### DIFF
--- a/README
+++ b/README
@@ -155,7 +155,7 @@ Samsung QX410 J01			Ben Sanders
 Asus U30JC				Julien-Charles		Ubuntu 10.10
 Lenovo T410				innoscopio		Linux Mint 11
 Asus N53SV/N53SN			Ximi1970		openSuSE 11.4 (i686/x86_64)
-
+Asus 1015PN				Aurelgadjo		Ubuntu 11.04 (i686/x86_64)
 
 Machines working with automatic power management of the nVidia card:
 

--- a/install-files/bumblebee-disablecard.1015PN
+++ b/install-files/bumblebee-disablecard.1015PN
@@ -1,11 +1,16 @@
 #!/bin/bash
 # This script should contain the command(s) nessesary to switch off the
-# nVidia card.
-# This is a template script..
+# nVidia card. It works on Asus 1015PN.
 # Please note that the acpi_call module is need for these operations:
 #
 # http://linux-hybrid-graphics.blogspot.com/2010/07/using-acpicall-module-to-switch-onoff.html
 # https://github.com/MrMEEE/bumblebee/issues/171
+
+if [ "$(id -u)" != "0" ] ; then 
+	echo "This script must be run as root or via sudo"
+	exit
+fi
+
 if ! lsmod | grep -q nvidia; then
     echo "Skipping: nVidia Card already disabled"
     exit
@@ -41,4 +46,8 @@ echo $(acpi_call "\_SB.PCI0.P0P4.DGPU.DOFF")
 
 # If I understood as well, this ACPI call just tells to hardware 
 # to enable both graphics cards at boot (and not just nvidia one)
-echo _PS0 $(acpi_call "\OSGS 0x03")
+# It has to be called at least one time at every boot. 
+if [ ! -f /tmp/acpi-call-1015PN.lock ] ; then 
+	touch /tmp/acpi-call-1015PN.lock
+	echo $(acpi_call "\OSGS 0x03")
+fi

--- a/install-files/bumblebee-enablecard.1015PN
+++ b/install-files/bumblebee-enablecard.1015PN
@@ -1,12 +1,15 @@
 #!/bin/bash
 # This script should contain the command(s) nessesary to switch on the
-# nVidia card.
-# This example originally comes from bumblebee project for the Asus 1215n, provided by BarzantMD..
-# It works on Asus1015PN.
+# nVidia card. It works on Asus 1015PN.
 # Please note that the acpi_call module is need for these operations:
 #
 # http://linux-hybrid-graphics.blogspot.com/2010/07/using-acpicall-module-to-switch-onoff.html
 # https://github.com/MrMEEE/bumblebee/issues/171
+
+if [ "$(id -u)" != "0" ] ; then
+	echo "This script must be run as root or via sudo"
+	exit
+fi
 
 if lsmod | grep -q nvidia; then
     echo "Skipping: nVidia Card already enabled"


### PR DESCRIPTION
Fixed typos on 1015PN scripts comments.
Added a "lock" mechanism to made the ACPI call to enable both 1015PN graphics card one time at every boot.
Added check to ensure that enable & disable scripts are called with superuser rights (else modprobe/rmmod fails then the enable & disable scripts are unable to work)
