### PR TITLE
Fix for Fedora installation

### DIFF
--- a/stages/backupconf.FEDORA
+++ b/stages/backupconf.FEDORA
@@ -1,12 +1,4 @@
-# Leave this in for old installs
-if [ `cat $BASHRC |grep VGL |wc -l` -ne 0 ]; then
-    cp $BASHRC.optiorig $BASHRC
-fi
-
 # Not present on FEDORA (15)
 if [ -f /etc/modules ]; then
     cp -n /etc/modules /etc/modules.optiorig
 fi
-
-# No need to fiddle with ${BASHRC} on Fedora as we use
-# /etc/profile.d here with our own file


### PR DESCRIPTION
Backup stage for Fedora installation has issues because BASHRC is not defined.  I cannot see anywhere that defines it during installation.

Attempting to restore $BASHRC from $BASHRC.optiorig doesn't work because BASHRC is not defined.  Worse, the condition causes installation to hang because cat waits on stdin.
