### PR TITLE
Fix installation issues on Ubuntu Oneiric

### DIFF
--- a/stages/installbumblebee.UBUNTU
+++ b/stages/installbumblebee.UBUNTU
@@ -46,9 +46,9 @@ cp install-files/bumblebee.script.ubuntu /etc/init.d/bumblebee
 if [ "$VERSION" = "oneiric" ]; then
  rm /etc/alternatives/*gl_conf
  if [ "$ARCH" = "x86_64" ]; then
-  ln -s /usr/lib/mesa/ld.so.conf /etc/alternatives/x86_64-linux-gnu_gl_conf
+  ln -s /usr/lib/x86_64-linux-gnu/mesa/ld.so.conf /etc/alternatives/x86_64-linux-gnu_gl_conf
  elif [ "$ARCH" = "i686" ]; then
-  ln -s /usr/lib/mesa/ld.so.conf /etc/alternatives/i386-linux-gnu_gl_conf
+  ln -s /usr/lib/i386-linux-gnu/mesa/ld.so.conf /etc/alternatives/i386-linux-gnu_gl_conf
  fi
  rm -rf /etc/alternatives/*xorg_extra_modules
  rm -rf /etc/alternatives/xorg_extra_modules-bumblebee


### PR DESCRIPTION
The pathnames of many library files in Ubuntu 11.10 Alpha (Oneiric) have been changed as part of the [Ubuntu Multiarch spec](https://wiki.ubuntu.com/MultiarchSpec). As a result, Bumblebee fails to link back the gl_conf alternative to the Mesa ld.so.conf file and also fails to remove the xorg_extra_modules link from /etc/alternatives. These commits fix the issues.
