### PR TITLE
It got broken on my 1015pn, so here is the fix

### DIFF
--- a/install-files/optirun.ubuntu
+++ b/install-files/optirun.ubuntu
@@ -126,7 +126,7 @@ display=${display%%.*}
 
 # test if Bumblebee's X server is running
 if [ ! -f /tmp/.X${display}-lock ]; then
- if [ `lspci -v -s $NVIDIABUSID |grep ! |wc -l` -eq 1 ]; then
+ if lspci -v -s $NVIDIABUSID |grep ! > /dev/null; then
   if ! sudo /etc/init.d/bumblebee enable; then
    echo "bumblebee could not be started - optirun cannot be executed."
    exit 1


### PR DESCRIPTION
"Is the card enabled" check didn't work. With hd audio there are 2 entries in lspci (both disabled) on the same device, so
-eq 1 won't cut it. And my version uses less PIDs :-)
